### PR TITLE
refactor mqa with repeat & transpose

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 - [x] support repeat in tensor
 - [x] benchmark matmuls
+- [ ] add batched matmul: (b, m, n) @ (b, n, o) => (b, m, o)
 - [ ] replace multi query attention with matmul with repeat
 - [ ] support quantization
 - [ ] take the tensor & device framework

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 - [x] support repeat in tensor
 - [x] benchmark matmuls
-- [ ] add transpose
-- [ ] add batched matmul: (b, m, n) @ (b, n, o) => (b, m, o)
-- [ ] replace multi query attention with matmul with repeat
+- [x] add transpose
+- [x] add batched matmul: (b, m, n) @ (b, n, o) => (b, m, o)
+- [x] replace multi query attention with matmul with repeat
   - key_cache: [seq, kv_head, head_size]
   - key_cache = key_cache.repeat(1, n_head / n_kv_head, 1) => [seq, n_head, head_size]
   - key_cache = key_cache.transpose(1, 0, 2) => [n_head, seq, head_size]

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 - [x] support repeat in tensor
-- [ ] benchmark matmuls
+- [x] benchmark matmuls
 - [ ] replace multi query attention with matmul with repeat
 - [ ] support quantization
 - [ ] take the tensor & device framework

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,12 @@
 - [x] benchmark matmuls
 - [ ] add batched matmul: (b, m, n) @ (b, n, o) => (b, m, o)
 - [ ] replace multi query attention with matmul with repeat
+  - key_cache: [seq, kv_head, head_size]
+  - key_cache = key_cache.repeat(1, n_head / n_kv_head, 1) => [seq, n_head, head_size]
+  - key_cache = key_cache.transpose(1, 0, 2) => [n_head, seq, head_size]
+  - q: [n_head, head_size]
+  - q = q.view([n_head, head_size, 1]) => [n_head, head_size, 1]
+  - attn_score = batch_matmul(key_cache, q)
 - [ ] support quantization
 - [ ] take the tensor & device framework
 - [ ] wgpu tensor support

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,6 @@
 - [x] support repeat in tensor
 - [x] benchmark matmuls
+- [ ] add transpose
 - [ ] add batched matmul: (b, m, n) @ (b, n, o) => (b, m, o)
 - [ ] replace multi query attention with matmul with repeat
   - key_cache: [seq, kv_head, head_size]

--- a/crabml-core/benches/matmul.rs
+++ b/crabml-core/benches/matmul.rs
@@ -2,7 +2,7 @@ use bencher::benchmark_group;
 use bencher::benchmark_main;
 
 use bencher::Bencher;
-use crabml::tensor::arithmetic::tensor_matmul_2d;
+use crabml::tensor::arithmetic::tensor_matmul;
 use crabml::tensor::arithmetic::tensor_matmul_specialized_2d_1d;
 use crabml::tensor::CpuTensor;
 use rayon::prelude::*;
@@ -58,7 +58,7 @@ fn benchmark_tensor_matmul(bench: &mut Bencher) {
     let w = CpuTensor::new(vec![1.0; 50000], vec![100, 500]).unwrap();
     let b = CpuTensor::new(vec![1.0; 500], vec![500]).unwrap();
     bench.iter(|| {
-        tensor_matmul_2d(&w, &b).unwrap();
+        tensor_matmul(&w, &b).unwrap();
     })
 }
 

--- a/crabml-core/src/tensor/arithmetic.rs
+++ b/crabml-core/src/tensor/arithmetic.rs
@@ -244,7 +244,6 @@ pub fn tensor_rope_inplace<'a>(
 
 fn require_tensor_shape(t: &CpuTensor, shape: &[usize]) -> Result<()> {
     if !t.shape().eq(shape) {
-        panic!("failed shape");
         return Err(Error {
             kind: ErrorKind::TensorError,
             message: format!("tensor shape is not {:?}, but {:?}", shape, t.shape(),),
@@ -380,4 +379,16 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_batch_matmul() -> Result<()> {
+        let w = CpuTensor::new(vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0], vec![2, 2, 3])?;
+        let b = CpuTensor::new(vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0], vec![2, 3, 1])?;
+ 
+        let o = tensor_batch_matmul(&w, &b)?;
+        assert_eq!(o.shape(), vec![2, 2, 1]);
+        assert_eq!(o.iter().cloned().collect::<Vec<_>>(), vec![3.0, 12.0, 21.0, 30.0]);
+        Ok(())
+    }
+
 }

--- a/crabml-core/src/tensor/arithmetic.rs
+++ b/crabml-core/src/tensor/arithmetic.rs
@@ -55,7 +55,7 @@ pub fn tensor_silu_inplace<'a>(mut x: CpuTensor<'a>) -> Result<CpuTensor<'a>> {
 
 // W (w_rows,w_cols) @ x (w_cols,x_cols) -> xout (w_rows,x_cols)
 // W (w_rows,w_cols) @ x (w_cols,) -> xout (w_rows,)
-pub fn tensor_matmul_2d<'a>(w: &CpuTensor<'a>, x: &CpuTensor<'a>) -> Result<CpuTensor<'a>> {
+pub fn tensor_matmul<'a>(w: &CpuTensor<'a>, x: &CpuTensor<'a>) -> Result<CpuTensor<'a>> {
     require_tensor_dims(w, &[2])?;
     require_tensor_dims(x, &[1, 2])?;
     require_tensor_matmul_2d_shapes(w, x)?;
@@ -378,7 +378,7 @@ mod tests {
         // 0
         // 1*1 + 2*2 + 3*3 = 1 + 4 + 9
         // 1*4 + 2*5 + 3*6 = 4 + 10 + 18
-        let out = tensor_matmul_2d(&w, &b)?;
+        let out = tensor_matmul(&w, &b)?;
         assert_eq!(out.iter().cloned().collect::<Vec<_>>(), &[14.0, 32.0]);
 
         // 1, 2, 3
@@ -394,7 +394,7 @@ mod tests {
             ],
             vec![3, 4],
         )?;
-        let out = tensor_matmul_2d(&w, &b)?;
+        let out = tensor_matmul(&w, &b)?;
         assert_eq!(
             out.iter().cloned().collect::<Vec<_>>(),
             &[38.0, 44.0, 50.0, 56.0, 83.0, 98.0, 113.0, 128.0]

--- a/crabml-core/src/tensor/arithmetic.rs
+++ b/crabml-core/src/tensor/arithmetic.rs
@@ -107,14 +107,19 @@ pub fn tensor_softmax_inplace<'a>(t: &mut CpuTensor<'a>, limit: usize) -> Result
         .iter_axis(&[0], 0)?
         .take(limit)
         .fold(f32::NAN, |a, b| a.max(*b));
-    let sum = t.iter_axis_mut(vec![0], 0)?.take(limit).fold(0.0, |mut acc, val| {
-        *val = (*val - max).exp();
-        acc += *val;
-        acc
-    });
-    t.par_iter_axis_mut(vec![0], 0)?.take(limit).for_each(|val| {
-        *val /= sum;
-    });
+    let sum = t
+        .iter_axis_mut(vec![0], 0)?
+        .take(limit)
+        .fold(0.0, |mut acc, val| {
+            *val = (*val - max).exp();
+            acc += *val;
+            acc
+        });
+    t.par_iter_axis_mut(vec![0], 0)?
+        .take(limit)
+        .for_each(|val| {
+            *val /= sum;
+        });
     Ok(())
 }
 

--- a/crabml-core/src/tensor/cpu.rs
+++ b/crabml-core/src/tensor/cpu.rs
@@ -180,10 +180,12 @@ impl<'a> CpuTensor<'a> {
         // iterate the original buf, and repeat each element `repeats[axis]` times.
         // if this axis is repeated, the original buf of this axis is `repeats[axis]` times smaller than
         // the shape. e.g. shape = [2, 6], repeats = [1, 2], then the actual buf is [2, 3]
-        // this is considered as a slow path, we'd not actually iter_axis around a repeated axis.
         if let Some(repeats) = self.strider.repeats() {
             let remains = (self.strider.shape()[axis] - pos[axis]) / repeats[axis] - 1;
             let buf = &self.buf[start..start + remains * stride + 1];
+            if repeats[axis] == 1 {
+                return Ok(CpuTensorAxisIter::StepBy(buf.iter().step_by(stride)));
+            }
             let iter = buf
                 .iter()
                 .step_by(stride)

--- a/crabml-core/src/tensor/cpu.rs
+++ b/crabml-core/src/tensor/cpu.rs
@@ -379,7 +379,11 @@ mod tests {
             },
         ];
         for tt in tests {
-            let r = tt.tensor.iter_axis(&tt.input.0, tt.input.1)?.cloned().collect::<Vec<_>>();
+            let r = tt
+                .tensor
+                .iter_axis(&tt.input.0, tt.input.1)?
+                .cloned()
+                .collect::<Vec<_>>();
             assert_eq!(r, tt.want);
         }
 
@@ -434,10 +438,14 @@ mod tests {
                 tensor: &t,
                 input: (vec![0, 0], 1),
                 want: vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
-            }
+            },
         ];
         for tt in tests {
-            let r = tt.tensor.iter_axis(&tt.input.0, tt.input.1)?.cloned().collect::<Vec<_>>();
+            let r = tt
+                .tensor
+                .iter_axis(&tt.input.0, tt.input.1)?
+                .cloned()
+                .collect::<Vec<_>>();
             assert_eq!(r, tt.want);
         }
 

--- a/crabml-core/src/tensor/cpu.rs
+++ b/crabml-core/src/tensor/cpu.rs
@@ -422,6 +422,16 @@ mod tests {
                 tensor: &t,
                 input: (vec![0, 5], 0),
                 want: vec![3.0, 6.0],
+            },
+            Test {
+                tensor: &t,
+                input: (vec![1, 0], 1),
+                want: vec![4.0, 4.0, 5.0, 5.0, 6.0, 6.0],
+            },
+            Test {
+                tensor: &t,
+                input: (vec![0, 0], 1),
+                want: vec![1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
             }
         ];
         for tt in tests {

--- a/crabml-core/src/tensor/cpu.rs
+++ b/crabml-core/src/tensor/cpu.rs
@@ -142,6 +142,14 @@ impl<'a> CpuTensor<'a> {
         })
     }
 
+    pub fn transpose(self, dims: &[usize]) -> Result<CpuTensor<'a>> {
+        let strider = self.strider.transpose(dims)?;
+        Ok(Self {
+            buf: self.buf,
+            strider,
+        })
+    }
+
     pub fn transpose_ref<'b>(&'b self, dims: &[usize]) -> Result<CpuTensor<'a>>
     where
         'b: 'a,

--- a/crabml-core/src/tensor/strider.rs
+++ b/crabml-core/src/tensor/strider.rs
@@ -340,7 +340,10 @@ mod tests {
         // 2, 2, 5, 5
         let s = s.repeat(vec![1, 2])?;
         assert_eq!(s.shape(), &[3, 4]);
-        assert_eq!(s.iter().collect::<Vec<_>>(), vec![0, 0, 3, 3, 1, 1, 4, 4, 2, 2, 5, 5]);
+        assert_eq!(
+            s.iter().collect::<Vec<_>>(),
+            vec![0, 0, 3, 3, 1, 1, 4, 4, 2, 2, 5, 5]
+        );
 
         // test transpose after repeat
 
@@ -350,14 +353,20 @@ mod tests {
         // 3, 4, 5
         // 3, 4, 5
         assert_eq!(s.shape(), &[4, 3]);
-        assert_eq!(s.iter().collect::<Vec<_>>(), vec![0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5]);
+        assert_eq!(
+            s.iter().collect::<Vec<_>>(),
+            vec![0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5]
+        );
 
         // 0, 0, 3, 3
         // 1, 1, 4, 4
         // 2, 2, 5, 5
         let s = s.transpose(&[1, 0])?;
         assert_eq!(s.shape(), &[3, 4]);
-        assert_eq!(s.iter().collect::<Vec<_>>(), vec![0, 0, 3, 3, 1, 1, 4, 4, 2, 2, 5, 5]);
+        assert_eq!(
+            s.iter().collect::<Vec<_>>(),
+            vec![0, 0, 3, 3, 1, 1, 4, 4, 2, 2, 5, 5]
+        );
         Ok(())
     }
 

--- a/crabml-core/src/tensor/strider.rs
+++ b/crabml-core/src/tensor/strider.rs
@@ -321,6 +321,47 @@ mod tests {
     }
 
     #[test]
+    fn test_transpose() -> Result<()> {
+        // 0, 1, 2
+        // 3, 4, 5
+        let s_orig = TensorStrider::new(vec![2, 3]);
+
+        // test repeat after transpose
+        // 0, 3
+        // 1, 4
+        // 2, 5
+        let s = s_orig.transpose(&[1, 0])?;
+        assert_eq!(s.shape(), &[3, 2]);
+        assert_eq!(s.iter().collect::<Vec<_>>(), vec![0, 3, 1, 4, 2, 5]);
+        assert_eq!(s.at(&[1, 1])?, 4);
+        assert_eq!(s.at(&[2, 1])?, 5);
+        // 0, 0, 3, 3
+        // 1, 1, 4, 4
+        // 2, 2, 5, 5
+        let s = s.repeat(vec![1, 2])?;
+        assert_eq!(s.shape(), &[3, 4]);
+        assert_eq!(s.iter().collect::<Vec<_>>(), vec![0, 0, 3, 3, 1, 1, 4, 4, 2, 2, 5, 5]);
+
+        // test transpose after repeat
+
+        let s = s_orig.repeat(vec![2, 1])?;
+        // 0, 1, 2
+        // 0, 1, 2
+        // 3, 4, 5
+        // 3, 4, 5
+        assert_eq!(s.shape(), &[4, 3]);
+        assert_eq!(s.iter().collect::<Vec<_>>(), vec![0, 1, 2, 0, 1, 2, 3, 4, 5, 3, 4, 5]);
+
+        // 0, 0, 3, 3
+        // 1, 1, 4, 4
+        // 2, 2, 5, 5
+        let s = s.transpose(&[1, 0])?;
+        assert_eq!(s.shape(), &[3, 4]);
+        assert_eq!(s.iter().collect::<Vec<_>>(), vec![0, 0, 3, 3, 1, 1, 4, 4, 2, 2, 5, 5]);
+        Ok(())
+    }
+
+    #[test]
     fn test_is_contigous() -> Result<()> {
         let s = TensorStrider::new(vec![2, 3]);
         assert!(s.is_contiguous());

--- a/crabml-core/src/tensor/strider.rs
+++ b/crabml-core/src/tensor/strider.rs
@@ -29,6 +29,10 @@ impl TensorStrider {
         &self.strides
     }
 
+    pub fn repeats(&self) -> Option<&Vec<usize>> {
+        self.repeats.as_ref()
+    }
+
     pub fn at(&self, idx: &[usize]) -> Result<usize> {
         if idx.len() != self.shape.len() {
             return Err((

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -350,7 +350,6 @@ impl<'a> Llama2Runner<'a> {
                     &q,
                     &self.state.key_cache[l],
                     &self.state.value_cache[l],
-                    pos,
                 )?;
                 let x_with_attn = x_with_attn.view(&[embed_dim])?;
 

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -260,10 +260,10 @@ impl<'a> Llama2Runner<'a> {
         let state = Llama2State {
             logits: vec![0.0; conf.vocab_size],
             key_cache: (0..conf.n_layers)
-                .map(|_| CpuTensor::zeros(vec![conf.seq_len, conf.n_kv_heads, conf.head_size()]))
+                .map(|_| CpuTensor::zeros(vec![0, conf.n_kv_heads, conf.head_size()]))
                 .collect::<Result<Vec<_>>>()?,
             value_cache: (0..conf.n_layers)
-                .map(|_| CpuTensor::zeros(vec![conf.seq_len, conf.n_kv_heads, conf.head_size()]))
+                .map(|_| CpuTensor::zeros(vec![0, conf.n_kv_heads, conf.head_size()]))
                 .collect::<Result<Vec<_>>>()?,
         };
 
@@ -333,8 +333,8 @@ impl<'a> Llama2Runner<'a> {
 
             // save to kv cache
             {
-                self.state.key_cache[l].copy_from(&[pos, 0, 0], &k)?;
-                self.state.value_cache[l].copy_from(&[pos, 0, 0], &v)?;
+                self.state.key_cache[l].extend(&k)?;
+                self.state.value_cache[l].extend(&v)?;
             };
 
             // multihead attention. iterate over all heads

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -8,6 +8,7 @@ use crabml::tensor::arithmetic::tensor_add_inplace;
 use crabml::tensor::arithmetic::tensor_matmul_2d;
 use crabml::tensor::arithmetic::tensor_mul_inplace;
 use crabml::tensor::arithmetic::tensor_multi_query_attention;
+use crabml::tensor::arithmetic::tensor_multi_query_attention2;
 use crabml::tensor::arithmetic::tensor_rms_norm_inplace;
 use crabml::tensor::arithmetic::tensor_rope_inplace;
 use crabml::tensor::arithmetic::tensor_silu_inplace;
@@ -346,7 +347,7 @@ impl<'a> Llama2Runner<'a> {
                 // q: (n_heads, head_size)
                 // key_cache: (seq, n_kv_heads, head_size)
                 // value_cache: (seq, kv_heads, head_size)
-                let x_with_attn = tensor_multi_query_attention(
+                let x_with_attn = tensor_multi_query_attention2(
                     &q,
                     &self.state.key_cache[l],
                     &self.state.value_cache[l],

--- a/crabml-llama2/src/llama2.rs
+++ b/crabml-llama2/src/llama2.rs
@@ -333,6 +333,8 @@ impl<'a> Llama2Runner<'a> {
 
             // save to kv cache
             {
+                let v = v.view(&[n_kv_heads, head_size])?;
+
                 self.state.key_cache[l].extend(&k)?;
                 self.state.value_cache[l].extend(&v)?;
             };


### PR DESCRIPTION
                - key_cache: [seq, kv_head, head_size]
                - key_cache = key_cache.repeat(1, n_head / n_kv_head, 1) => [seq, n_head, head_size]
                - key_cache = key_cache.transpose(1, 0, 2) => [n_head, seq, head_size]
                - q: [n_head, head_size]
                - attn_score = batch_matmul(key_cache, q) => [n_head, seq]
                - softmax(attn_score, axis=1) => [n_head, seq]
                - val_cache: [seq, kv_head, head_size]
                - val_cache = val_cache.repeat(1, n_head / n_kv_head, 1) => [seq, n_head, head_size]
                - val_cache = val_cache.transpose(1, 2, 0) => [n_head, head_size, seq]
                - out = batch_matmul(val_cache, atten_scores) => [n_head, head_size] 