### PR TITLE
refactor: unify dequantize

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,9 @@
   - learn the kv cache layout
 - [x] use uniform to store the meta buffers
 - [x] a better gemv
+- [x] refactor the buf code
+- [ ] seek again why ggml is faster on inferencing 3B model with CPU
+  - [ ] plot the time duration during matmul and batch matmul
 - [ ] q8 quantization on webgpu
   - [ ] add dequantize in CpuTensor
   - [ ] refactor the CPU side: dequantize these on loading: token_embedding_table, rms_att_weight, rms_ffn_weight, rms_final_weight, wcls

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [x] a better gemv
 - [x] refactor the buf code
 - [ ] seek again why ggml is faster on inferencing 3B model with CPU
-  - [ ] plot the time duration during matmul and batch matmul
+  - [ ] plot the time duration during matmul and batch matmul in GGML
 - [ ] q8 quantization on webgpu
   - [ ] add dequantize in CpuTensor
   - [ ] refactor the CPU side: dequantize these on loading: token_embedding_table, rms_att_weight, rms_ffn_weight, rms_final_weight, wcls

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@
   - learn the kv cache layout
 - [x] use uniform to store the meta buffers
 - [x] a better gemv
-- [ ] move copy_from to buf 
 - [ ] q8 quantization on webgpu
   - [ ] add dequantize in CpuTensor
   - [ ] refactor the CPU side: dequantize these on loading: token_embedding_table, rms_att_weight, rms_ffn_weight, rms_final_weight, wcls

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
   - learn the kv cache layout
 - [x] use uniform to store the meta buffers
 - [x] a better gemv
+- [ ] move copy_from to buf 
 - [ ] q8 quantization on webgpu
   - [ ] add dequantize in CpuTensor
   - [ ] refactor the CPU side: dequantize these on loading: token_embedding_table, rms_att_weight, rms_ffn_weight, rms_final_weight, wcls

--- a/crabml-cli/src/main.rs
+++ b/crabml-cli/src/main.rs
@@ -57,10 +57,10 @@ fn main() -> Result<()> {
     let device_wgpu = WgpuTensorDevice::new(
         WgpuTensorDeviceOptions::new().with_staging_buf_bytes(conf.vocab_size * 4),
     );
-    let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
+    // let model_wgpu = WgpuLlama2Model::from_cpu(&model_cpu, device_wgpu)?;
 
     let mut sampler = Llama2Sampler::new(conf.vocab_size, args.temperature, args.probability);
-    let mut runner = Llama2Runner::try_from(&model_wgpu)?;
+    let mut runner = Llama2Runner::try_from(&model_cpu)?;
 
     if args.verbose {
         for tensor in gf.tensor_infos() {

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -22,13 +22,6 @@ impl<'a> CpuTensorBuf<'a> {
         }
     }
 
-    pub fn at_unchecked(&self, pos: usize) -> f32 {
-        match self {
-            CpuTensorBuf::F32(buf) => buf[pos],
-            CpuTensorBuf::Q8_0(buf) => buf.dequantize(pos).next().unwrap(),
-        }
-    }
-
     pub fn is_owned(&self) -> bool {
         match self {
             CpuTensorBuf::F32(Cow::Owned(_)) => true,

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -42,17 +42,10 @@ impl<'a> CpuTensorBuf<'a> {
         }
     }
 
-    pub fn typ(&self) -> GGMLType {
+    pub fn dtype(&self) -> GGMLType {
         match self {
             CpuTensorBuf::F32(_) => GGMLType::F32,
             CpuTensorBuf::Q8_0(_) => GGMLType::Q8_0,
-        }
-    }
-
-    pub fn as_ref(&'a self) -> CpuTensorBuf<'a> {
-        match self {
-            CpuTensorBuf::F32(buf) => CpuTensorBuf::F32(Cow::Borrowed(buf.as_ref())),
-            CpuTensorBuf::Q8_0(buf) => CpuTensorBuf::Q8_0(buf.clone()),
         }
     }
 

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -100,6 +100,20 @@ impl<'a> CpuTensorBuf<'a> {
         Ok(())
     }
 
+    pub fn as_f32_ref(&self) -> &[f32] {
+        match self {
+            CpuTensorBuf::F32(buf) => buf,
+            _ => panic!("not f32, but got {:?}", self.dtype()),
+        }
+    }
+
+    pub fn as_f32_mut(&mut self) -> &mut [f32] {
+        match self {
+            CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
+            _ => panic!("not f32, but got {:?}", self.dtype()),
+        }
+    }
+
     /// the quantized tensor can not be iterated directly. to iterate the quantized tensor,
     /// use `dequantize` to convert it to f32/f16 tensor first.
     pub fn iter_f32(&self) -> impl Iterator<Item = f32> + '_ {

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::slice;
 
 use crate::backends::cpu::buf::QuantBufQ8_0;
+use crate::error::ErrorKind;
 use crate::error::Result;
 use crate::gguf::GGMLType;
 
@@ -46,6 +47,26 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(_) => GGMLType::F32,
             CpuTensorBuf::Q8_0(_) => GGMLType::Q8_0,
+        }
+    }
+
+    /// dequantize the quantized tensors to f32 or f16
+    ///
+    /// - a f32 buf can not be dequantized to f16
+    /// - a f16 buf can only be dequantized to f32 or f16
+    /// - the lower bit quantized buf can be dequantized to f32 or f16
+    pub fn dequantize(self, dtype: GGMLType) -> Result<Self> {
+        if dtype != GGMLType::F32 || dtype != GGMLType::F16 {
+            return Err((
+                ErrorKind::TensorError,
+                format!("dequantize to {:?} is not supported", dtype),
+            )
+                .into());
+        }
+
+        match self {
+            CpuTensorBuf::F32(buf) => Ok(CpuTensorBuf::F32(buf)),
+            CpuTensorBuf::Q8_0(buf) => todo!(),
         }
     }
 

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -54,7 +54,7 @@ impl<'a> CpuTensorBuf<'a> {
     /// f32 to f16 is not considered as dequantization, but it still will be supported to
     /// simplify the conversion on half-precision activation is enabled.
     pub fn dequantize(self, dtype: GGMLType) -> Result<Self> {
-        if dtype != GGMLType::F32 || dtype != GGMLType::F16 {
+        if dtype != GGMLType::F32 && dtype != GGMLType::F16 {
             return Err((
                 ErrorKind::TensorError,
                 format!("dequantize to {:?} is not supported", dtype),

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -50,11 +50,9 @@ impl<'a> CpuTensorBuf<'a> {
         }
     }
 
-    /// dequantize the quantized tensors to f32 or f16
-    ///
-    /// - a f32 buf can not be dequantized to f16
-    /// - a f16 buf can only be dequantized to f32 or f16
-    /// - the lower bit quantized buf can be dequantized to f32 or f16
+    /// dequantize the quantized tensors to f32 or f16.
+    /// f32 to f16 is not considered as dequantization, but it still will be supported to
+    /// simplify the conversion on half-precision activation is enabled.
     pub fn dequantize(self, dtype: GGMLType) -> Result<Self> {
         if dtype != GGMLType::F32 || dtype != GGMLType::F16 {
             return Err((

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -154,7 +154,3 @@ impl<'a> From<&'a [f32]> for CpuTensorBuf<'a> {
         Self::F32(buf.into())
     }
 }
-
-pub trait CpuTensorBufVecDot {
-    fn vec_dot_f32(&self, row: usize, x: &[f32]) -> f32;
-}

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -25,7 +25,7 @@ impl<'a> CpuTensorBuf<'a> {
     pub fn at_unchecked(&self, pos: usize) -> f32 {
         match self {
             CpuTensorBuf::F32(buf) => buf[pos],
-            CpuTensorBuf::Q8_0(buf) => buf.iter_range(pos, pos + 1, 1).next().unwrap(),
+            CpuTensorBuf::Q8_0(buf) => buf.iter_range(pos, pos + 1).next().unwrap(),
         }
     }
 
@@ -65,7 +65,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => Ok(CpuTensorBuf::F32(buf)),
             CpuTensorBuf::Q8_0(buf) => match dtype {
-                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.iter_range(0, buf.len(), 1).collect())),
+                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.iter_range(0, buf.len()).collect())),
                 _ => unimplemented!(),
             },
         }
@@ -82,7 +82,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => CpuTensorBufIter::Slice(buf.iter()),
             CpuTensorBuf::Q8_0(buf) => {
-                CpuTensorBufIter::Boxed(Box::new(buf.iter_range(0, buf.len(), 1)), self.len())
+                CpuTensorBufIter::Boxed(Box::new(buf.iter_range(0, buf.len())), self.len())
             }
         }
     }
@@ -93,7 +93,7 @@ impl<'a> CpuTensorBuf<'a> {
                 CpuTensorBufIter::Boxed(Box::new(buf.iter().skip(pos).cloned()), self.len() - pos)
             }
             CpuTensorBuf::Q8_0(buf) => {
-                CpuTensorBufIter::Boxed(Box::new(buf.iter_range(pos, buf.len(), 1)), self.len())
+                CpuTensorBufIter::Boxed(Box::new(buf.iter_range(pos, buf.len())), self.len())
             }
         }
     }

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -65,6 +65,17 @@ impl<'a> CpuTensorBuf<'a> {
         }
     }
 
+    pub fn iter_from(&self, pos: usize) -> CpuTensorBufIter {
+        match self {
+            CpuTensorBuf::F32(buf) => {
+                CpuTensorBufIter::Boxed(Box::new(buf.iter().skip(pos).cloned()), self.len() - pos)
+            }
+            CpuTensorBuf::Q8_0(buf) => {
+                CpuTensorBufIter::Boxed(Box::new(buf.iter_range(pos, buf.len(), 1)), self.len())
+            }
+        }
+    }
+
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut f32> {
         match self {
             CpuTensorBuf::F32(Cow::Owned(buf)) => buf.iter_mut(),

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -63,30 +63,6 @@ impl<'a> CpuTensorBuf<'a> {
         }
     }
 
-    pub fn iter_range(&self, start: usize, end: usize, step: usize) -> CpuTensorBufIter {
-        match self {
-            CpuTensorBuf::F32(buf) => {
-                CpuTensorBufIter::StepBy(buf[start..end].iter().step_by(step))
-            }
-            CpuTensorBuf::Q8_0(buf) => CpuTensorBufIter::Boxed(
-                Box::new(buf.iter_range(start, end, step)),
-                self.len() / step,
-            ),
-        }
-    }
-
-    pub fn iter_range_mut(
-        &mut self,
-        start: usize,
-        end: usize,
-        step: usize,
-    ) -> impl ExactSizeIterator<Item = &mut f32> {
-        match self {
-            CpuTensorBuf::F32(Cow::Owned(buf)) => buf[start..end].iter_mut().step_by(step),
-            _ => unreachable!("only owned buffers can be mutable"),
-        }
-    }
-
     pub fn iter(&self) -> CpuTensorBufIter {
         match self {
             CpuTensorBuf::F32(buf) => CpuTensorBufIter::Slice(buf.iter()),

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -25,7 +25,7 @@ impl<'a> CpuTensorBuf<'a> {
     pub fn at_unchecked(&self, pos: usize) -> f32 {
         match self {
             CpuTensorBuf::F32(buf) => buf[pos],
-            CpuTensorBuf::Q8_0(buf) => buf.iter_range(pos, pos + 1).next().unwrap(),
+            CpuTensorBuf::Q8_0(buf) => buf.iter_from(pos).next().unwrap(),
         }
     }
 
@@ -65,7 +65,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => Ok(CpuTensorBuf::F32(buf)),
             CpuTensorBuf::Q8_0(buf) => match dtype {
-                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.iter_range(0, buf.len()).collect())),
+                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.iter_from(0).collect())),
                 _ => unimplemented!(),
             },
         }
@@ -82,7 +82,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => CpuTensorBufIter::Slice(buf.iter()),
             CpuTensorBuf::Q8_0(buf) => {
-                CpuTensorBufIter::Boxed(Box::new(buf.iter_range(0, buf.len())), self.len())
+                CpuTensorBufIter::Boxed(Box::new(buf.iter_from(0)), self.len())
             }
         }
     }
@@ -93,7 +93,7 @@ impl<'a> CpuTensorBuf<'a> {
                 CpuTensorBufIter::Boxed(Box::new(buf.iter().skip(pos).cloned()), self.len() - pos)
             }
             CpuTensorBuf::Q8_0(buf) => {
-                CpuTensorBufIter::Boxed(Box::new(buf.iter_range(pos, buf.len())), self.len())
+                CpuTensorBufIter::Boxed(Box::new(buf.iter_from(pos)), self.len())
             }
         }
     }

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -25,7 +25,7 @@ impl<'a> CpuTensorBuf<'a> {
     pub fn at_unchecked(&self, pos: usize) -> f32 {
         match self {
             CpuTensorBuf::F32(buf) => buf[pos],
-            CpuTensorBuf::Q8_0(buf) => buf.dequantize_from(pos).next().unwrap(),
+            CpuTensorBuf::Q8_0(buf) => buf.dequantize(pos).next().unwrap(),
         }
     }
 
@@ -65,7 +65,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => Ok(CpuTensorBuf::F32(buf)),
             CpuTensorBuf::Q8_0(buf) => match dtype {
-                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.dequantize_from(0).collect())),
+                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.dequantize(0).collect())),
                 _ => unimplemented!(),
             },
         }
@@ -82,7 +82,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => CpuTensorBufIter::Slice(buf.iter()),
             CpuTensorBuf::Q8_0(buf) => {
-                CpuTensorBufIter::Boxed(Box::new(buf.dequantize_from(0)), self.len())
+                CpuTensorBufIter::Boxed(Box::new(buf.dequantize(0)), self.len())
             }
         }
     }
@@ -193,6 +193,6 @@ impl<'a> ExactSizeIterator for CpuTensorBufIter<'a> {
     }
 }
 
-pub trait QuantizedBuf {
+pub trait CpuTensorBufVecDot {
     fn vec_dot_f32(&self, row: usize, x: &[f32]) -> f32;
 }

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -66,7 +66,10 @@ impl<'a> CpuTensorBuf<'a> {
 
         match self {
             CpuTensorBuf::F32(buf) => Ok(CpuTensorBuf::F32(buf)),
-            CpuTensorBuf::Q8_0(buf) => todo!(),
+            CpuTensorBuf::Q8_0(buf) => match dtype {
+                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.iter_range(0, buf.len(), 1).collect())),
+                _ => unimplemented!(),
+            },
         }
     }
 

--- a/crabml-core/src/backends/cpu/buf/buf.rs
+++ b/crabml-core/src/backends/cpu/buf/buf.rs
@@ -25,7 +25,7 @@ impl<'a> CpuTensorBuf<'a> {
     pub fn at_unchecked(&self, pos: usize) -> f32 {
         match self {
             CpuTensorBuf::F32(buf) => buf[pos],
-            CpuTensorBuf::Q8_0(buf) => buf.iter_from(pos).next().unwrap(),
+            CpuTensorBuf::Q8_0(buf) => buf.dequantize_from(pos).next().unwrap(),
         }
     }
 
@@ -65,7 +65,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => Ok(CpuTensorBuf::F32(buf)),
             CpuTensorBuf::Q8_0(buf) => match dtype {
-                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.iter_from(0).collect())),
+                GGMLType::F32 => Ok(CpuTensorBuf::F32(buf.dequantize_from(0).collect())),
                 _ => unimplemented!(),
             },
         }
@@ -82,7 +82,7 @@ impl<'a> CpuTensorBuf<'a> {
         match self {
             CpuTensorBuf::F32(buf) => CpuTensorBufIter::Slice(buf.iter()),
             CpuTensorBuf::Q8_0(buf) => {
-                CpuTensorBufIter::Boxed(Box::new(buf.iter_from(0)), self.len())
+                CpuTensorBufIter::Boxed(Box::new(buf.dequantize_from(0)), self.len())
             }
         }
     }
@@ -93,7 +93,7 @@ impl<'a> CpuTensorBuf<'a> {
                 CpuTensorBufIter::Boxed(Box::new(buf.iter().skip(pos).cloned()), self.len() - pos)
             }
             CpuTensorBuf::Q8_0(buf) => {
-                CpuTensorBufIter::Boxed(Box::new(buf.iter_from(pos)), self.len())
+                CpuTensorBufIter::Boxed(Box::new(buf.dequantize_from(pos)), self.len())
             }
         }
     }
@@ -182,6 +182,6 @@ impl<'a> ExactSizeIterator for CpuTensorBufIter<'a> {
     }
 }
 
-pub trait VecDotF32 {
+pub trait QuantizedBuf {
     fn vec_dot_f32(&self, row: usize, x: &[f32]) -> f32;
 }

--- a/crabml-core/src/backends/cpu/buf/buf_f32.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f32.rs
@@ -1,8 +1,22 @@
 use std::borrow::Cow;
 use std::simd::f32x32;
 use std::simd::prelude::SimdFloat;
+use std::slice;
 
 use super::buf::CpuTensorBufVecDot;
+
+pub fn f32_buf_from_bytes<'a>(buf: &[u8]) -> Cow<'a, [f32]> {
+    let len = buf.len();
+    assert_eq!(
+        len % std::mem::size_of::<f32>(),
+        0,
+        "Length of slice must be multiple of f32 size"
+    );
+    let new_len = len / std::mem::size_of::<f32>();
+    let ptr = buf.as_ptr() as *const f32;
+    let f32_buf = unsafe { slice::from_raw_parts(ptr, new_len) };
+    f32_buf.into()
+}
 
 impl<'a> CpuTensorBufVecDot for Cow<'a, [f32]> {
     fn vec_dot_f32(&self, offset: usize, x: &[f32]) -> f32 {

--- a/crabml-core/src/backends/cpu/buf/buf_f32.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f32.rs
@@ -3,8 +3,6 @@ use std::simd::f32x32;
 use std::simd::prelude::SimdFloat;
 use std::slice;
 
-use super::buf::CpuTensorBufVecDot;
-
 pub fn f32_buf_from_bytes<'a>(buf: &[u8]) -> Cow<'a, [f32]> {
     let len = buf.len();
     assert_eq!(

--- a/crabml-core/src/backends/cpu/buf/buf_f32.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f32.rs
@@ -18,15 +18,13 @@ pub fn f32_buf_from_bytes<'a>(buf: &[u8]) -> Cow<'a, [f32]> {
     f32_buf.into()
 }
 
-impl<'a> CpuTensorBufVecDot for Cow<'a, [f32]> {
-    fn vec_dot_f32(&self, offset: usize, x: &[f32]) -> f32 {
-        let chunks = self[offset..offset + x.len()].chunks(32);
-        let mut acc = f32x32::splat(0.0);
-        for (chunk_idx, chunk) in chunks.enumerate() {
-            let block = f32x32::from_slice(chunk);
-            let x = f32x32::from_slice(&x[chunk_idx * 32..(chunk_idx + 1) * 32]);
-            acc += block * x;
-        }
-        acc.reduce_sum()
+pub fn f32_buf_vec_dot_f32(lhs: &[f32], offset: usize, x: &[f32]) -> f32 {
+    let chunks = lhs[offset..offset + x.len()].chunks(32);
+    let mut acc = f32x32::splat(0.0);
+    for (chunk_idx, chunk) in chunks.enumerate() {
+        let block = f32x32::from_slice(chunk);
+        let x = f32x32::from_slice(&x[chunk_idx * 32..(chunk_idx + 1) * 32]);
+        acc += block * x;
     }
+    acc.reduce_sum()
 }

--- a/crabml-core/src/backends/cpu/buf/buf_f32.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f32.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::simd::f32x32;
 use std::simd::prelude::SimdFloat;
 
-use super::buf::QuantizedBuf;
+use super::buf::CpuTensorBufVecDot;
 
-impl<'a> QuantizedBuf for Cow<'a, [f32]> {
+impl<'a> CpuTensorBufVecDot for Cow<'a, [f32]> {
     fn vec_dot_f32(&self, offset: usize, x: &[f32]) -> f32 {
         let chunks = self[offset..offset + x.len()].chunks(32);
         let mut acc = f32x32::splat(0.0);

--- a/crabml-core/src/backends/cpu/buf/buf_f32.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_f32.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::simd::f32x32;
 use std::simd::prelude::SimdFloat;
 
-use super::buf::VecDotF32;
+use super::buf::QuantizedBuf;
 
-impl<'a> VecDotF32 for Cow<'a, [f32]> {
+impl<'a> QuantizedBuf for Cow<'a, [f32]> {
     fn vec_dot_f32(&self, offset: usize, x: &[f32]) -> f32 {
         let chunks = self[offset..offset + x.len()].chunks(32);
         let mut acc = f32x32::splat(0.0);

--- a/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
@@ -30,17 +30,11 @@ impl<'a> QuantBufQ8_0<'a> {
         self.num_blocks * 32
     }
 
-    pub fn iter_range(
-        &'a self,
-        start: usize,
-        end: usize,
-        step: usize,
-    ) -> impl Iterator<Item = f32> + 'a {
+    pub fn iter_range(&'a self, start: usize, end: usize) -> impl Iterator<Item = f32> + 'a {
         BlockBufIterQ8_0 {
             buf: &self,
             pos: start,
             end: end,
-            step: step,
             current_f32_buf: [0.0; 32],
             current_block: usize::MAX,
         }
@@ -133,7 +127,6 @@ pub struct BlockBufIterQ8_0<'a> {
     current_block: usize,
     pos: usize,
     end: usize,
-    step: usize,
 }
 
 impl<'a> Iterator for BlockBufIterQ8_0<'a> {
@@ -152,7 +145,7 @@ impl<'a> Iterator for BlockBufIterQ8_0<'a> {
         }
 
         let val = self.current_f32_buf[self.pos % 32];
-        self.pos += self.step;
+        self.pos += 1;
         Some(val)
     }
 }
@@ -185,12 +178,12 @@ mod tests {
 
         let bf = QuantBufQ8_0::from_bytes(&buf);
         assert_eq!(bf.len(), 64);
-        assert_eq!(bf.iter_range(0, bf.len(), 1).collect::<Vec<_>>(), vec![
+        assert_eq!(bf.iter_range(0, bf.len()).collect::<Vec<_>>(), vec![
             6.0, 9.0, 12.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
             3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 21.0, 3.0, 3.0,
             3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
             3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 27.0, 27.0
         ]);
-        assert_eq!(bf.iter_range(10, bf.len(), 1).collect::<Vec<_>>().len(), 54);
+        assert_eq!(bf.iter_range(10, bf.len()).collect::<Vec<_>>().len(), 54);
     }
 }

--- a/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
@@ -3,7 +3,7 @@ use std::simd::prelude::SimdFloat;
 
 use half::f16;
 
-use super::buf::VecDotF32;
+use super::buf::QuantizedBuf;
 
 #[derive(Debug, Clone)]
 pub struct QuantBufQ8_0<'a> {
@@ -30,7 +30,7 @@ impl<'a> QuantBufQ8_0<'a> {
         self.num_blocks * 32
     }
 
-    pub fn iter_from(&'a self, start: usize) -> impl Iterator<Item = f32> + 'a {
+    pub fn dequantize_from(&'a self, start: usize) -> impl Iterator<Item = f32> + 'a {
         assert!(start % 32 == 0);
 
         let block_start = start / 32;
@@ -90,7 +90,7 @@ impl BlockQ8_0 {
     }
 }
 
-impl<'a> VecDotF32 for QuantBufQ8_0<'a> {
+impl<'a> QuantizedBuf for QuantBufQ8_0<'a> {
     fn vec_dot_f32(&self, offset: usize, x: &[f32]) -> f32 {
         let blocks = BlockQ8_0::from_bytes(self.raw);
         let row = &blocks[offset / 32..(offset + x.len()) / 32];
@@ -149,7 +149,7 @@ mod tests {
 
         let bf = QuantBufQ8_0::from_bytes(&buf);
         assert_eq!(bf.len(), 64);
-        assert_eq!(bf.iter_from(0).collect::<Vec<_>>(), vec![
+        assert_eq!(bf.dequantize_from(0).collect::<Vec<_>>(), vec![
             6.0, 9.0, 12.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
             3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 21.0, 3.0, 3.0,
             3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,

--- a/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
@@ -3,7 +3,7 @@ use std::simd::prelude::SimdFloat;
 
 use half::f16;
 
-use super::buf::QuantizedBuf;
+use super::CpuTensorBufVecDot;
 
 #[derive(Debug, Clone)]
 pub struct QuantBufQ8_0<'a> {
@@ -30,7 +30,7 @@ impl<'a> QuantBufQ8_0<'a> {
         self.num_blocks * 32
     }
 
-    pub fn dequantize_from(&'a self, start: usize) -> impl Iterator<Item = f32> + 'a {
+    pub fn dequantize(&'a self, start: usize) -> impl Iterator<Item = f32> + 'a {
         assert!(start % 32 == 0);
 
         let block_start = start / 32;
@@ -90,7 +90,7 @@ impl BlockQ8_0 {
     }
 }
 
-impl<'a> QuantizedBuf for QuantBufQ8_0<'a> {
+impl<'a> CpuTensorBufVecDot for QuantBufQ8_0<'a> {
     fn vec_dot_f32(&self, offset: usize, x: &[f32]) -> f32 {
         let blocks = BlockQ8_0::from_bytes(self.raw);
         let row = &blocks[offset / 32..(offset + x.len()) / 32];
@@ -149,7 +149,7 @@ mod tests {
 
         let bf = QuantBufQ8_0::from_bytes(&buf);
         assert_eq!(bf.len(), 64);
-        assert_eq!(bf.dequantize_from(0).collect::<Vec<_>>(), vec![
+        assert_eq!(bf.dequantize(0).collect::<Vec<_>>(), vec![
             6.0, 9.0, 12.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,
             3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 21.0, 3.0, 3.0,
             3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0,

--- a/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
+++ b/crabml-core/src/backends/cpu/buf/buf_q8_0.rs
@@ -3,8 +3,6 @@ use std::simd::prelude::SimdFloat;
 
 use half::f16;
 
-use super::CpuTensorBufVecDot;
-
 #[derive(Debug, Clone)]
 pub struct QuantBufQ8_0<'a> {
     raw: &'a [u8],

--- a/crabml-core/src/backends/cpu/buf/mod.rs
+++ b/crabml-core/src/backends/cpu/buf/mod.rs
@@ -4,6 +4,6 @@ pub mod buf_q8_0;
 
 pub use buf::CpuTensorBuf;
 pub use buf::CpuTensorBufIter;
-pub use buf::QuantizedBuf;
+pub use buf::CpuTensorBufVecDot;
 pub use buf_q8_0::BlockQ8_0;
 pub use buf_q8_0::QuantBufQ8_0;

--- a/crabml-core/src/backends/cpu/buf/mod.rs
+++ b/crabml-core/src/backends/cpu/buf/mod.rs
@@ -3,7 +3,6 @@ pub mod buf_f32;
 pub mod buf_q8_0;
 
 pub use buf::CpuTensorBuf;
-pub use buf::CpuTensorBufIter;
 pub use buf::CpuTensorBufVecDot;
 pub use buf_q8_0::BlockQ8_0;
 pub use buf_q8_0::QuantBufQ8_0;

--- a/crabml-core/src/backends/cpu/buf/mod.rs
+++ b/crabml-core/src/backends/cpu/buf/mod.rs
@@ -3,5 +3,4 @@ pub mod buf_f32;
 pub mod buf_q8_0;
 
 pub use buf::CpuTensorBuf;
-pub use buf::CpuTensorBufVecDot;
 pub use buf_q8_0::QuantBufQ8_0;

--- a/crabml-core/src/backends/cpu/buf/mod.rs
+++ b/crabml-core/src/backends/cpu/buf/mod.rs
@@ -4,5 +4,4 @@ pub mod buf_q8_0;
 
 pub use buf::CpuTensorBuf;
 pub use buf::CpuTensorBufVecDot;
-pub use buf_q8_0::BlockQ8_0;
 pub use buf_q8_0::QuantBufQ8_0;

--- a/crabml-core/src/backends/cpu/buf/mod.rs
+++ b/crabml-core/src/backends/cpu/buf/mod.rs
@@ -4,6 +4,6 @@ pub mod buf_q8_0;
 
 pub use buf::CpuTensorBuf;
 pub use buf::CpuTensorBufIter;
-pub use buf::VecDotF32;
+pub use buf::QuantizedBuf;
 pub use buf_q8_0::BlockQ8_0;
 pub use buf_q8_0::QuantBufQ8_0;

--- a/crabml-core/src/backends/cpu/cpu_device.rs
+++ b/crabml-core/src/backends/cpu/cpu_device.rs
@@ -54,7 +54,7 @@ impl<'a> CpuTensorDevice<'a> {
     }
 
     pub(crate) fn add_debug_tensor(&self, tensor: &CpuTensor<'a>) {
-        let buf = tensor.buf().iter().collect::<Vec<_>>();
+        let buf = tensor.buf().iter_f32().collect::<Vec<_>>();
         self.debug_tensors
             .borrow_mut()
             .insert(tensor.name.clone().unwrap(), buf);

--- a/crabml-core/src/backends/cpu/cpu_device.rs
+++ b/crabml-core/src/backends/cpu/cpu_device.rs
@@ -49,13 +49,6 @@ impl<'a> CpuTensorDevice<'a> {
         Rc::new(device)
     }
 
-    pub fn export_tensor(self: Rc<Self>, tensor: &CpuTensor<'a>, dst: &mut [f32]) -> Result<()> {
-        tensor.iter().zip(dst.iter_mut()).for_each(|(src, dst)| {
-            *dst = src;
-        });
-        Ok(())
-    }
-
     pub fn dump_debug_tensor(&self, name: &str) -> Option<Vec<f32>> {
         self.debug_tensors.borrow().get(name).cloned()
     }

--- a/crabml-core/src/backends/cpu/cpu_device.rs
+++ b/crabml-core/src/backends/cpu/cpu_device.rs
@@ -4,7 +4,6 @@ use std::rc::Rc;
 
 use super::CpuTensor;
 use crate::backends::cpu::buf::CpuTensorBuf;
-use crate::error::Result;
 
 #[derive(Debug, Clone)]
 pub struct CpuTensorDeviceOptions {

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -87,7 +87,7 @@ impl<'a> CpuTensor<'a> {
 
     fn to_vec(&self) -> Vec<f32> {
         assert!(self.is_contiguous());
-        return self.buf.iter().collect();
+        return self.buf.iter_f32().collect();
     }
 
     pub fn is_contiguous(&self) -> bool {
@@ -181,7 +181,7 @@ impl<'a> Tensor for CpuTensor<'a> {
                 .into());
         }
 
-        self.buf.extend(t.buf.iter());
+        self.buf.extend(t.buf.iter_f32());
         let new_shape = {
             let mut shape = self.shape().to_vec();
             shape[0] += 1;
@@ -232,16 +232,18 @@ impl<'a> Tensor for CpuTensor<'a> {
     }
 
     fn dup(&self) -> Result<Self> {
-        let buf = self.buf.iter().collect::<Vec<_>>();
+        let buf = self.buf.iter_f32().collect::<Vec<_>>();
         Self::new(buf, self.shape(), self.device.clone())
     }
 
     fn export(&self, dst: &mut [f32]) -> Result<()> {
         assert!(self.is_contiguous());
 
-        dst.iter_mut().zip(self.buf.iter()).for_each(|(dst, src)| {
-            *dst = src;
-        });
+        dst.iter_mut()
+            .zip(self.buf.iter_f32())
+            .for_each(|(dst, src)| {
+                *dst = src;
+            });
         Ok(())
     }
 

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -219,6 +219,17 @@ impl<'a> Tensor for CpuTensor<'a> {
         if !src.is_contiguous() {
             return Err((ErrorKind::TensorError, "src tensor is not contiguous").into());
         }
+        if self.dtype() != src.dtype() {
+            return Err((
+                ErrorKind::TensorError,
+                format!(
+                    "dtype mismatch on copy_from, want {:?} but got {:?}",
+                    self.dtype(),
+                    src.dtype()
+                ),
+            )
+                .into());
+        }
 
         let src_idx = src.strider().at(pos)?;
         let src_iter = src.buf.iter_from(src_idx).take(len);

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -1,6 +1,5 @@
 use super::CpuTensorDeviceRef;
 use crate::backends::cpu::buf::CpuTensorBuf;
-use crate::backends::cpu::buf::CpuTensorBufIter;
 use crate::backends::cpu::primitives;
 use crate::error::Error;
 use crate::error::ErrorKind;

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -85,8 +85,10 @@ impl<'a> CpuTensor<'a> {
         self.buf.is_owned()
     }
 
+    /// to_vec is only used for test.
     fn to_vec(&self) -> Vec<f32> {
         assert!(self.is_contiguous());
+        // TODO: if it's f16, convert it to f32
         return self.buf.iter_f32().collect();
     }
 

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -228,13 +228,8 @@ impl<'a> Tensor for CpuTensor<'a> {
                 .into());
         }
 
-        let src_idx = src.strider().at(pos)?;
-        let src_iter = src.buf.iter_from(src_idx).take(len);
-
-        self.buf.iter_mut().zip(src_iter).for_each(|(dst, src)| {
-            *dst = src;
-        });
-        Ok(())
+        let offset = src.strider().at(pos)?;
+        self.buf.copy_from(&src.buf, offset, len)
     }
 
     fn dup(&self) -> Result<Self> {

--- a/crabml-core/src/backends/cpu/cpu_tensor.rs
+++ b/crabml-core/src/backends/cpu/cpu_tensor.rs
@@ -58,7 +58,16 @@ impl<'a> CpuTensor<'a> {
     }
 
     pub fn dequantize(self, dtype: GGMLType) -> Result<Self> {
-        todo!()
+        let strider = self.strider.clone();
+        let device = self.device.clone();
+        let name = self.name.clone();
+        let buf = self.buf.dequantize(dtype)?;
+        Ok(Self {
+            buf,
+            strider,
+            device,
+            name,
+        })
     }
 
     pub fn typ(&self) -> GGMLType {

--- a/crabml-core/src/backends/cpu/primitives/add.rs
+++ b/crabml-core/src/backends/cpu/primitives/add.rs
@@ -13,8 +13,10 @@ pub fn add_inplace<'a>(
     assert!(strider1.is_contiguous());
     assert!(strider2.is_contiguous());
 
-    buf1.iter_mut().zip(buf2.iter()).for_each(|(ia, ib)| {
-        *ia += ib;
-    });
+    buf1.iter_f32_mut()
+        .zip(buf2.iter_f32())
+        .for_each(|(ia, ib)| {
+            *ia += ib;
+        });
     Ok(())
 }

--- a/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
@@ -6,34 +6,22 @@ use crate::tensor::TensorStrider;
 
 // (b, m, k) @ (b, k, ) -> (b, m, )
 // a is allowed to be not contiguous, but not quantized
-pub fn batch_matmul_vec<'a, 'b>(
+pub fn batch_matmul_vec<'a>(
     a: &CpuTensorBuf<'a>,
-    b: &CpuTensorBuf<'b>,
-    c: &mut CpuTensorBuf<'b>,
+    b: &CpuTensorBuf<'a>,
+    c: &mut CpuTensorBuf<'a>,
     strider1: &TensorStrider,
     strider2: &TensorStrider,
-) -> Result<()>
-where
-    'b: 'a,
-{
+) -> Result<()> {
     assert!(strider1.shape().len() == 3);
     assert!(strider2.shape().len() == 2);
     assert!(strider1.shape()[0] == strider2.shape()[0]);
     assert!(strider1.shape()[2] == strider2.shape()[1]);
     assert!(strider2.is_contiguous());
 
-    let bufa = match a {
-        CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
-        _ => panic!("only support f32 yet"),
-    };
-    let bufb = match b {
-        CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
-        _ => panic!("only support f32 yet"),
-    };
-    let bufc = match c {
-        CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
-        _ => panic!("only support f32 yet"),
-    };
+    let bufa = a.as_f32_ref();
+    let bufb = b.as_f32_ref();
+    let bufc = c.as_f32_mut();
 
     let batch = strider1.shape()[0];
     let m = strider1.shape()[1];

--- a/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/batch_matmul_vec.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::backends::cpu::buf::CpuTensorBuf;
 use crate::error::Result;
 use crate::tensor::TensorStrider;

--- a/crabml-core/src/backends/cpu/primitives/div.rs
+++ b/crabml-core/src/backends/cpu/primitives/div.rs
@@ -14,15 +14,17 @@ pub fn div_inplace<'a>(
     assert!(strider2.is_contiguous());
 
     if buf2.len() == 1 {
-        let ib = buf2.iter().next().unwrap();
-        buf1.iter_mut().for_each(|ia| {
+        let ib = buf2.iter_f32().next().unwrap();
+        buf1.iter_f32_mut().for_each(|ia| {
             *ia /= ib;
         });
         return Ok(());
     }
 
-    buf1.iter_mut().zip(buf2.iter()).for_each(|(ia, ib)| {
-        *ia /= ib;
-    });
+    buf1.iter_f32_mut()
+        .zip(buf2.iter_f32())
+        .for_each(|(ia, ib)| {
+            *ia /= ib;
+        });
     Ok(())
 }

--- a/crabml-core/src/backends/cpu/primitives/div.rs
+++ b/crabml-core/src/backends/cpu/primitives/div.rs
@@ -14,7 +14,7 @@ pub fn div_inplace<'a>(
     assert!(strider2.is_contiguous());
 
     if buf2.len() == 1 {
-        let ib = buf2.at_unchecked(0);
+        let ib = buf2.iter().next().unwrap();
         buf1.iter_mut().for_each(|ia| {
             *ia /= ib;
         });

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rayon::prelude::*;
 
 use crate::backends::cpu::buf::CpuTensorBuf;
-use crate::backends::cpu::buf::QuantizedBuf;
+use crate::backends::cpu::buf::CpuTensorBufVecDot;
 use crate::error::Result;
 use crate::tensor::TensorStrider;
 
@@ -89,7 +89,7 @@ pub fn maybe_matmul_vec_simd<'a, 'b: 'a>(
     true
 }
 
-pub fn matmul_vec_generic_xxx_f32_simd<'a, T: QuantizedBuf + Sync>(
+pub fn matmul_vec_generic_xxx_f32_simd<'a, T: CpuTensorBufVecDot + Sync>(
     a: &T,
     b: &[f32],
     c: &mut [f32],

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -63,8 +63,15 @@ fn gemv_simd_f32<'a>(
     let bufb = bufb.as_f32_ref();
 
     let k = bufb.len();
-    bufc.par_iter_mut().enumerate().for_each(|(mi, cp)| {
-        let offset = mi * k;
-        *cp = bufa.vec_dot_f32(offset, bufb);
+    bufc.par_chunks_mut(8).enumerate().for_each(|(cn, cp)| {
+        let mi = cn * 8;
+        cp[0] = bufa.vec_dot_f32(mi * k, bufb);
+        cp[1] = bufa.vec_dot_f32((mi + 1) * k, bufb);
+        cp[2] = bufa.vec_dot_f32((mi + 2) * k, bufb);
+        cp[3] = bufa.vec_dot_f32((mi + 3) * k, bufb);
+        cp[4] = bufa.vec_dot_f32((mi + 4) * k, bufb);
+        cp[5] = bufa.vec_dot_f32((mi + 5) * k, bufb);
+        cp[6] = bufa.vec_dot_f32((mi + 6) * k, bufb);
+        cp[7] = bufa.vec_dot_f32((mi + 7) * k, bufb);
     });
 }

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use rayon::prelude::*;
 
 use crate::backends::cpu::buf::CpuTensorBuf;
-use crate::backends::cpu::buf::VecDotF32;
+use crate::backends::cpu::buf::QuantizedBuf;
 use crate::error::Result;
 use crate::tensor::TensorStrider;
 
@@ -89,7 +89,11 @@ pub fn maybe_matmul_vec_simd<'a, 'b: 'a>(
     true
 }
 
-pub fn matmul_vec_generic_xxx_f32_simd<'a, T: VecDotF32 + Sync>(a: &T, b: &[f32], c: &mut [f32]) {
+pub fn matmul_vec_generic_xxx_f32_simd<'a, T: QuantizedBuf + Sync>(
+    a: &T,
+    b: &[f32],
+    c: &mut [f32],
+) {
     // a: [m, k]
     // b: [k]
     // out: [m]

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -3,12 +3,11 @@ use std::borrow::Cow;
 use rayon::prelude::*;
 
 use crate::backends::cpu::buf::CpuTensorBuf;
-use crate::backends::cpu::buf::CpuTensorBufVecDot;
 use crate::error::Result;
 use crate::tensor::TensorStrider;
 
 // matmul_vec is an implementation of GEMV: A (m,k) @ B (k,) -> xout (m,).
-// A is allowed to be not contiguous, and quantized
+// A is allowed to be not contiguous and quantized
 pub fn matmul_vec<'a>(
     bufa: &CpuTensorBuf<'a>,
     bufb: &CpuTensorBuf<'a>,
@@ -21,85 +20,53 @@ pub fn matmul_vec<'a>(
     assert!(strider1.shape()[1] == strider2.shape()[0]);
     assert!(strider2.is_contiguous());
 
-    let m = strider1.shape()[0];
-    let k = strider1.shape()[1];
-
-    let ok = maybe_matmul_vec_simd(bufa, bufb, bufc, &strider1);
-    if ok {
+    // if the input is contiguous, we can use SIMD to accelerate the computation
+    if strider1.is_contiguous() && bufa.len() % 32 == 0 {
+        gemv_simd_f32(bufa, bufb, bufc);
         return Ok(());
     }
 
-    let out = match bufc {
-        CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
-        _ => panic!("only support f32 yet"),
-    };
-    let a = match bufa {
-        CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
-        _ => panic!("only support f32 yet"),
-    };
-    let b = match bufb {
-        CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
-        _ => panic!("only support f32 yet"),
-    };
+    // fall back to the naive implementation if stride1 is not contiguous
+    gemv_naive_f32(bufa, bufb, bufc, strider1);
+    return Ok(());
+}
 
+fn gemv_naive_f32<'a>(
+    bufa: &CpuTensorBuf<'a>,
+    bufb: &CpuTensorBuf<'a>,
+    bufc: &mut CpuTensorBuf<'a>,
+    strider1: &TensorStrider,
+) {
+    let c = bufc.as_f32_mut();
+    let a = bufa.as_f32_ref();
+    let b = bufb.as_f32_ref();
     let m_stride = strider1.strides()[0];
     let k_stride = strider1.strides()[1];
+    let m = strider1.shape()[0];
+    let k = strider1.shape()[1];
 
     for mi in 0..m {
         let mut sum = 0.0;
         for ki in 0..k {
             sum += a[mi * m_stride + ki * k_stride] * b[ki];
         }
-        out[mi] = sum;
+        c[mi] = sum;
     }
-
-    return Ok(());
 }
 
-pub fn maybe_matmul_vec_simd<'a, 'b: 'a>(
+fn gemv_simd_f32<'a>(
     bufa: &CpuTensorBuf<'a>,
-    bufb: &CpuTensorBuf<'b>,
+    bufb: &CpuTensorBuf<'a>,
     bufc: &mut CpuTensorBuf<'a>,
-    strider1: &TensorStrider,
-) -> bool {
-    if !strider1.is_contiguous() {
-        return false;
-    }
-    let bufc = match bufc {
-        CpuTensorBuf::F32(Cow::Owned(buf)) => buf,
-        _ => return false,
-    };
-
-    match (bufa, bufb) {
-        (CpuTensorBuf::Q8_0(bufa), CpuTensorBuf::F32(bufb)) => {
-            if bufa.len() % 32 != 0 {
-                return false;
-            }
-            matmul_vec_generic_xxx_f32_simd(bufa, bufb, bufc);
-        }
-        (CpuTensorBuf::F32(bufa), CpuTensorBuf::F32(bufb)) => {
-            if bufa.len() % 32 != 0 {
-                return false;
-            }
-            matmul_vec_generic_xxx_f32_simd(bufa, bufb, bufc);
-        }
-        _ => return false,
-    };
-
-    true
-}
-
-pub fn matmul_vec_generic_xxx_f32_simd<'a, T: CpuTensorBufVecDot + Sync>(
-    a: &T,
-    b: &[f32],
-    c: &mut [f32],
 ) {
-    // a: [m, k]
-    // b: [k]
-    // out: [m]
-    let k = b.len();
-    c.par_iter_mut().enumerate().for_each(|(mi, cp)| {
+    assert!(bufa.len() % 32 == 0);
+
+    let bufc = bufc.as_f32_mut();
+    let bufb = bufb.as_f32_ref();
+
+    let k = bufb.len();
+    bufc.par_iter_mut().enumerate().for_each(|(mi, cp)| {
         let offset = mi * k;
-        *cp = a.vec_dot_f32(offset, b);
+        *cp = bufa.vec_dot_f32(offset, bufb);
     });
 }

--- a/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
+++ b/crabml-core/src/backends/cpu/primitives/matmul_vec.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use rayon::prelude::*;
 
 use crate::backends::cpu::buf::CpuTensorBuf;

--- a/crabml-core/src/backends/cpu/primitives/mul.rs
+++ b/crabml-core/src/backends/cpu/primitives/mul.rs
@@ -17,7 +17,7 @@ pub fn mul_inplace<'a>(
     assert!(strider2.is_contiguous());
     assert!(buf1.dtype() == buf2.dtype());
 
-    for (ia, ib) in buf1.iter_mut().zip(buf2.iter()) {
+    for (ia, ib) in buf1.iter_f32_mut().zip(buf2.iter_f32()) {
         *ia *= ib;
     }
 

--- a/crabml-core/src/backends/cpu/primitives/mul.rs
+++ b/crabml-core/src/backends/cpu/primitives/mul.rs
@@ -4,7 +4,7 @@ use crate::backends::cpu::buf::CpuTensorBuf;
 use crate::error::Result;
 use crate::tensor::TensorStrider;
 
-// buf1 have to be owned, buf2 can be quantized
+// both buf1 and buf2 have to be owned, the dtype should be the same
 pub fn mul_inplace<'a>(
     buf1: &mut CpuTensorBuf<'a>,
     buf2: &CpuTensorBuf<'a>,
@@ -15,6 +15,7 @@ pub fn mul_inplace<'a>(
     assert!(strider1.shape() == strider2.shape());
     assert!(strider1.is_contiguous());
     assert!(strider2.is_contiguous());
+    assert!(buf1.dtype() == buf2.dtype());
 
     for (ia, ib) in buf1.iter_mut().zip(buf2.iter()) {
         *ia *= ib;

--- a/crabml-core/src/backends/cpu/primitives/rms_norm.rs
+++ b/crabml-core/src/backends/cpu/primitives/rms_norm.rs
@@ -23,9 +23,9 @@ pub fn rms_norm_inplace<'a>(
     }
 
     let len = strider.shape()[0];
-    let sum = buf.iter().fold(0.0, |s, n| s + n * n);
+    let sum = buf.iter_f32().fold(0.0, |s, n| s + n * n);
     let rms = ((sum / len as f32) + eps).sqrt();
-    buf.iter_mut().for_each(|n| *n = *n / rms);
+    buf.iter_f32_mut().for_each(|n| *n = *n / rms);
     Ok(())
 }
 

--- a/crabml-core/src/backends/cpu/primitives/silu.rs
+++ b/crabml-core/src/backends/cpu/primitives/silu.rs
@@ -3,6 +3,7 @@ use crate::error::Result;
 
 // TODO: support f16
 pub fn silu_inplace<'a>(buf: &mut CpuTensorBuf<'a>) -> Result<()> {
-    buf.iter_mut().for_each(|n| *n = *n / (1.0 + (-*n).exp()));
+    buf.iter_f32_mut()
+        .for_each(|n| *n = *n / (1.0 + (-*n).exp()));
     Ok(())
 }

--- a/crabml-core/src/backends/wgpu/wgpu_tensor.rs
+++ b/crabml-core/src/backends/wgpu/wgpu_tensor.rs
@@ -108,6 +108,10 @@ impl Tensor for WgpuTensor {
         })
     }
 
+    fn dtype(&self) -> GGMLType {
+        self.dtype
+    }
+
     fn with_strider(self, strider: TensorStrider) -> Result<Self> {
         Ok(Self {
             buf: self.buf,

--- a/crabml-core/src/tensor/tensor.rs
+++ b/crabml-core/src/tensor/tensor.rs
@@ -1,5 +1,6 @@
 use super::strider::TensorStrider;
 use crate::error::Result;
+use crate::gguf::GGMLType;
 
 pub trait Tensor: Sized + Clone {
     type Device: Clone;
@@ -8,6 +9,8 @@ pub trait Tensor: Sized + Clone {
     /// only F32 and F16 (not yet implemented) are supported.
     /// TODO: add dtype parameter
     fn alloc(shape: &[usize], capacity: Option<usize>, device: Self::Device) -> Result<Self>;
+
+    fn dtype(&self) -> GGMLType;
 
     fn with_strider(self, strider: TensorStrider) -> Result<Self>;
 

--- a/crabml-core/src/tensor/tensor.rs
+++ b/crabml-core/src/tensor/tensor.rs
@@ -27,6 +27,7 @@ pub trait Tensor: Sized + Clone {
     fn extend(&mut self, rhs: &Self) -> Result<()>;
 
     /// copy from another tensor. used on loading weights from vocab table.
+    /// the src and dst tensor must have the same dtype.
     fn copy_from(&mut self, rhs: &Self, pos: &[usize], len: usize) -> Result<()>;
 
     fn export(&self, buf: &mut [f32]) -> Result<()>;

--- a/crabml-core/src/tensor/tensor.rs
+++ b/crabml-core/src/tensor/tensor.rs
@@ -26,6 +26,7 @@ pub trait Tensor: Sized + Clone {
 
     fn extend(&mut self, rhs: &Self) -> Result<()>;
 
+    /// copy from another tensor. used on loading weights from vocab table.
     fn copy_from(&mut self, rhs: &Self, pos: &[usize], len: usize) -> Result<()>;
 
     fn export(&self, buf: &mut [f32]) -> Result<()>;

--- a/crabml-llama2/src/model.rs
+++ b/crabml-llama2/src/model.rs
@@ -366,3 +366,27 @@ impl WgpuLlama2Model {
         Ok(wgpu_tensor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crabml::backends::cpu::CpuTensorDevice;
+    use crabml::error::Result;
+    use crabml::gguf::GGMLType;
+    use crabml::gguf::GGUFFileLoader;
+    use crabml::tensor::Tensor;
+
+    use crate::CpuLlama2Model;
+
+    #[test]
+    fn test_load_q8_0() -> Result<()> {
+        let gl = GGUFFileLoader::new("../testdata/tinyllamas-stories-15m-q8_0.gguf")?;
+        let gf = gl.open()?;
+
+        let device = CpuTensorDevice::new();
+        let lm = CpuLlama2Model::load(&gf, device)?;
+        assert_eq!(lm.conf.vocab_size, 32000);
+        assert_eq!(lm.weights.rms_att_weight[0].dtype(), GGMLType::F32);
+        assert_eq!(lm.weights.wk[0].dtype(), GGMLType::Q8_0);
+        Ok(())
+    }
+}


### PR DESCRIPTION
- only use dequantize on loading the weights for vocab_table
- make all the primitives except GEMV are f32 only.